### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "require-dev": {
         "doctrine/dbal": "^2.2",
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "^5.7",
         "scrutinizer/ocular": "~1.3",
-        "satooshi/php-coveralls": "^1.0"
+        "php-coveralls/php-coveralls": "^1.0"
     }
 }

--- a/tests/IPv4Network/IPv4NetworkTest.php
+++ b/tests/IPv4Network/IPv4NetworkTest.php
@@ -13,8 +13,9 @@ namespace GpsLab\Component\Tests\Interval\IPv4Network;
 use GpsLab\Component\Interval\IPv4Network\IPv4Network;
 use GpsLab\Component\Interval\IPv4Network\IPv4NetworkMask;
 use GpsLab\Component\Interval\IPv4Network\IPv4NetworkPoint;
+use PHPUnit\Framework\TestCase;
 
-class IPv4NetworkTest extends \PHPUnit_Framework_TestCase
+class IPv4NetworkTest extends TestCase
 {
     /**
      * @return array

--- a/tests/IPv6/IPv6IntervalPointTest.php
+++ b/tests/IPv6/IPv6IntervalPointTest.php
@@ -11,8 +11,9 @@
 namespace GpsLab\Component\Tests\Interval\IPv6;
 
 use GpsLab\Component\Interval\IPv6\IPv6IntervalPoint;
+use PHPUnit\Framework\TestCase;
 
-class IPv6IntervalPointTest extends \PHPUnit_Framework_TestCase
+class IPv6IntervalPointTest extends TestCase
 {
     /**
      * @return array

--- a/tests/IPv6/IPv6IntervalTest.php
+++ b/tests/IPv6/IPv6IntervalTest.php
@@ -12,8 +12,9 @@ namespace GpsLab\Component\Tests\Interval\IPv6;
 
 use GpsLab\Component\Interval\IntervalType;
 use GpsLab\Component\Interval\IPv6\IPv6Interval;
+use PHPUnit\Framework\TestCase;
 
-class IPv6IntervalTest extends \PHPUnit_Framework_TestCase
+class IPv6IntervalTest extends TestCase
 {
     /**
      * @return array

--- a/tests/IPv6Network/IPv6NetworkTest.php
+++ b/tests/IPv6Network/IPv6NetworkTest.php
@@ -12,8 +12,9 @@ namespace GpsLab\Component\Tests\Interval\IPv6Network;
 
 use GpsLab\Component\Interval\IPv6Network\IPv6Network;
 use GpsLab\Component\Interval\IPv6Network\IPv6NetworkPoint;
+use PHPUnit\Framework\TestCase;
 
-class IPv6NetworkTest extends \PHPUnit_Framework_TestCase
+class IPv6NetworkTest extends TestCase
 {
     /**
      * @return array


### PR DESCRIPTION
# Changed log
- To be compatible with future PHPUnit versions, using the `PHPUnit\Framework\TestCase` class namespace instead.
- The `satooshi/php-coveralls` package is deprecated, using the `php-coveralls/php-coveralls` instead.