### PR TITLE
Requires SQL comment hint for DBAL types

### DIFF
--- a/src/Persistence/Doctrine/DBAL/Types/BaseType.php
+++ b/src/Persistence/Doctrine/DBAL/Types/BaseType.php
@@ -63,6 +63,14 @@ abstract class BaseType extends TextType
     }
 
     /**
+     * @return bool
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+
+    /**
      * @return string
      */
     abstract protected function getIntervalClass();

--- a/tests/Persistence/Doctrine/DBAL/Types/IntervalTypeTest.php
+++ b/tests/Persistence/Doctrine/DBAL/Types/IntervalTypeTest.php
@@ -223,4 +223,14 @@ class IntervalTypeTest extends TestCase
     {
         return call_user_func([$class, 'fromString'], $interval);
     }
+
+    /**
+     * @dataProvider getTypes
+     *
+     * @param BaseType $type
+     */
+    public function testRequiresSQLCommentHint(BaseType $type)
+    {
+        $this->assertTrue($type->requiresSQLCommentHint($this->platform));
+    }
 }


### PR DESCRIPTION
Fix deprecation error

```
The type "TimeInterval" was implicitly marked as commented due to the configuration. This is deprecated and will be removed in DoctrineBundle 2.0. Either set the "commented" attribute in the configuration to "false" or mark the type as commented in "GpsLab\Component\Interval\Persistence\Doctrine\DBAL\Types\TimeIntervalType::requiresSQLCommentHint()." {"exception":"[object] (ErrorException(code: 0): User Deprecated: The type \"TimeInterval\" was implicitly marked as commented due to the configuration. This is deprecated and will be removed in DoctrineBundle 2.0. Either set the \"commented\" attribute in the configuration to \"false\" or mark the type as commented in \"GpsLab\\Component\\Interval\\Persistence\\Doctrine\\DBAL\\Types\\TimeIntervalType::requiresSQLCommentHint().\" at /application/vendor/doctrine/doctrine-bundle/ConnectionFactory.php:122)"} []
```