### PR TITLE
Don't make Scrutinizer wait for Coverage

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,4 +2,4 @@ imports:
     - php
 
 tools:
-    external_code_coverage: true
+    external_code_coverage: false


### PR DESCRIPTION
Coveralls config is currently present in this repo. Codecov can be eventually added after #23 gets merged