### PR TITLE
Mark IntervalType as immutable

### DIFF
--- a/src/IntervalType.php
+++ b/src/IntervalType.php
@@ -15,6 +15,7 @@ use GpsLab\Component\Interval\Exception\InvalidIntervalFormatException;
 
 /**
  * @see https://en.wikipedia.org/wiki/Interval_(mathematics)
+ * @psalm-immutable
  */
 final class IntervalType
 {


### PR DESCRIPTION
It prevents psalm analysis errors:

> Cannot call an possibly-mutating method GpsLab\Component\Interval\IntervalType::startExcluded from a mutation-free context (see https://psalm.dev/203)